### PR TITLE
Shorten phenotype columns to fix index creation with new mysql

### DIFF
--- a/finngen_common_data_model/colocalization.py
+++ b/finngen_common_data_model/colocalization.py
@@ -393,9 +393,9 @@ class Colocalization(Kwargs, JSONifiable):
                 Column('{}colocalization_id'.format(prefix), Integer, primary_key=True, autoincrement=False),
                 Column('{}source1'.format(prefix), String(80), unique=False, nullable=False),
                 Column('{}source2'.format(prefix), String(80), unique=False, nullable=False),
-                Column('{}phenotype1'.format(prefix), String(1000), unique=False, nullable=False),
+                Column('{}phenotype1'.format(prefix), String(500), unique=False, nullable=False),
                 Column('{}phenotype1_description'.format(prefix), String(1000), unique=False, nullable=False),
-                Column('{}phenotype2'.format(prefix), String(1000), unique=False, nullable=False),
+                Column('{}phenotype2'.format(prefix), String(500), unique=False, nullable=False),
                 Column('{}phenotype2_description'.format(prefix), String(1000), unique=False, nullable=False),
 
                 Column('{}quant1'.format(prefix), String(80), unique=False, nullable=True),


### PR DESCRIPTION
Change phenotype length to varchar 500, try to fix index creation problems. The indices in question are in here: https://github.com/FINNGEN/pheweb-colocalization/blob/1c80a276e34c5e2bc6b29f0429b1410ba32b1d83/pheweb_colocalization/model_mapper.py#L76-L85

```python
self.colocalization_phenotype1 = Index('colocalization_phenotype1',
                                       colocalization_table.c.phenotype1)

self.colocalization_phenotype2 = Index('colocalization_phenotype2',
                                       colocalization_table.c.phenotype2)

self.colocalization_phenotype1_chromosome = Index('colocalization_phenotype1_chromosome',
                                                  colocalization_table.c.phenotype1,
                                                  colocalization_table.c.chromosome)
```

The reason for this is that mysql has a maximum index length of 3072 bytes. We use utf8mb4 in r11 colocalization table (might be related to newer mysql version), as opposed to the utf8 in earlier colocalization tables, which is an alias to utf8mb3 in mysql 8 and earlier. So each character takes 1 byte more in R11 table than in earlier tables. The total size of the index colocalization_phenotype1_chromosome is then sizeof(smallint) + sizeof(varchar(1000)) = sizeof(smallint) + 1000*4  >= 4000 >3072.
So, to fix this, I checked the max size of the phenotypes, which was way less than 500 characters (200 characters if I remember correctly), and set the size of phenotypes to 500 characters, which is 2000 bytes. Making the index a bit larger than 2000 bytes.

 